### PR TITLE
modify videoUploader/VideoEncodingStatusChecker

### DIFF
--- a/src/objects/ad-video.js
+++ b/src/objects/ad-video.js
@@ -73,7 +73,7 @@ export default class AdVideo extends AbstractCrudObject {
       throw Error('Invalid Video ID');
     }
 
-    VideoEncodingStatusChecker.waitUntilReady(
+    return VideoEncodingStatusChecker.waitUntilReady(
       this.getApi(),
       this['id'],
       interval,

--- a/src/video-uploader.js
+++ b/src/video-uploader.js
@@ -428,8 +428,8 @@ class VideoEncodingStatusChecker {
     let status = null;
 
     while (true) {
-      status = VideoEncodingStatusChecker.getStatus(api, videoId);
-      status = status['video_status'];
+      status = await VideoEncodingStatusChecker.getStatus(api, videoId);
+      status = status['status']['video_status'];
 
       if (status !== 'processing') {
         break;
@@ -450,7 +450,7 @@ class VideoEncodingStatusChecker {
   static getStatus (api: FacebookAdsApi, videoId: Number) {
     const result = api.call('GET', [parseInt(videoId)], {fields: 'status'});
 
-    return result['status'];
+    return result;
   }
 }
 


### PR DESCRIPTION
Method `api.call` return a Promise in _videoUploader/getStatus_, so I add a `await` before the call to `getStatus` .

Beside, also add `return` in _ad_video/VideoEncodingStatusChecker_ so that external call can make a chain operation: 
```
advideo.waitUntilEncodingReady(1000, 10000).then(status => {
    console.log(status)
    ...
})
```