### PR TITLE
Moved build dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,19 +52,19 @@
     "rollup-plugin-node-resolve": "~2.0.0",
     "rollup-stream": "~1.14.0",
     "vinyl-buffer": "~1.0.0",
-    "vinyl-source-stream": "~1.1.0"
-  },
-  "dependencies": {
+    "vinyl-source-stream": "~1.1.0",
     "babel-eslint": "^7.2.3",
     "babel-plugin-async-to-promises": "^1.0.5",
     "eslint-plugin-flowtype": "^2.34.0",
     "gulp-cli": "^1.3.0",
     "gulp-flowtype": "^1.0.0",
     "jshint-sourcemap-reporter": "0.0.1",
+    "semistandard": "^11.0.0"
+  },
+  "dependencies": {
     "mixwith": "~0.1.1",
     "request": "^2.81.0",
     "request-promise": "~4.1.1",
-    "semistandard": "^11.0.0"
   },
   "scripts": {
     "prepublish": "gulp dist",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "mixwith": "~0.1.1",
     "request": "^2.81.0",
-    "request-promise": "~4.1.1",
+    "request-promise": "~4.1.1"
   },
   "scripts": {
     "prepublish": "gulp dist",


### PR DESCRIPTION
This fix is to reduce the size of the node modules by moving build dependencies to devDependencies.
Related issue https://github.com/facebook/facebook-nodejs-business-sdk/issues/52