### PR TITLE
Removed social_impressions from ad insights fields.

### DIFF
--- a/src/objects/ads-insights.js
+++ b/src/objects/ads-insights.js
@@ -61,7 +61,6 @@ export default class AdsInsights extends AbstractCrudObject {
       place_page_name: 'place_page_name',
       reach: 'reach',
       relevance_score: 'relevance_score',
-      social_impressions: 'social_impressions',
       social_spend: 'social_spend',
       spend: 'spend',
       total_action_value: 'total_action_value',


### PR DESCRIPTION
social_impressions are no longer valid for AdInsights fields. Removed to avoid errors.