### PR TITLE
Inject appsecret_proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ For now, we can use the <a href="https://developers.facebook.com/tools/explorer"
 ```javaScript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof);
 ```
 
 ### Api main class
@@ -112,7 +113,8 @@ You can access object properties like this:
 ```javaScript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof);
 const AdAccount = adsSdk.AdAccount;
 const Campaign = adsSdk.Campaign;
 const account = new AdAccount('act_<AD_ACCOUNT_ID>');
@@ -138,7 +140,8 @@ account
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const AdAccount = adsSdk.AdAccount;
 const account = new AdAccount('act_<AD_ACCOUNT_ID>');
 account
@@ -157,7 +160,8 @@ Requesting an high number of fields may cause the response time to visibly incre
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const AdAccount = adsSdk.AdAccount;
 const Campaign = adsSdk.Campaign;
 const account = new AdAccount('act_<AD_ACCOUNT_ID>');
@@ -181,7 +185,8 @@ account
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const Campaign = adsSdk.Campaign;
 const campaignId = <CAMPAIGN_ID>;
 new Campaign(campaignId, {
@@ -195,7 +200,8 @@ new Campaign(campaignId, {
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const Campaign = adsSdk.Campaign;
 const campaignId = <CAMPAIGN_ID>;
 new Campaign(campaignId).delete();
@@ -211,7 +217,8 @@ Here the `Cursor` is a superpowered `Array` (with all it's native helpful operat
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const AdAccount = adsSdk.AdAccount;
 const Campaign = adsSdk.Campaign;
 const account = new AdAccount('act_<AD_ACCOUNT_ID>');
@@ -244,7 +251,8 @@ If you are using cursor to iterate all of your object under your Ad Account, thi
 ```javascript
 const adsSdk = require('facebook-nodejs-ads-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 const AdAccount = adsSdk.AdAccount;
 const account = new AdAccount('act_<AD_ACCOUNT_ID>');
 
@@ -266,7 +274,8 @@ A `FacebookAdsApi` object offers a debugging mode that will log all requests. To
 ```javascript
 const adsSdk = require('facebook-nodejs-business-sdk');
 const accessToken = '<VALID_ACCESS_TOKEN>';
-const api = adsSdk.FacebookAdsApi.init(accessToken);
+const appsecret_proof = '<VALID_APPSECRET_PROOF>'; //optional
+const api = adsSdk.FacebookAdsApi.init(accessToken, appsecret_proof)
 api.setDebug(true);
 ```
 

--- a/src/api.js
+++ b/src/api.js
@@ -16,6 +16,7 @@ import {FacebookRequestError} from './exceptions';
 export default class FacebookAdsApi {
   _debug: boolean;
   accessToken: string;
+  appsecret_proof: string;
   locale: string;
   static _defaultApi: FacebookAdsApi;
   static get VERSION () {
@@ -33,11 +34,12 @@ export default class FacebookAdsApi {
    * @param {String} accessToken
    * @param {String} [locale]
    */
-  constructor (accessToken: string, locale: string = 'en_US') {
+  constructor (accessToken: string, appsecret_proof: string = null, locale: string = 'en_US') {
     if (!accessToken) {
       throw new Error('Access token required');
     }
     this.accessToken = accessToken;
+    this.appsecret_proof = appsecret_proof
     this.locale = locale;
     this._debug = false;
   }
@@ -93,11 +95,23 @@ export default class FacebookAdsApi {
     if (typeof path !== 'string' && !(path instanceof String)) {
       url = [domain, FacebookAdsApi.VERSION, ...path].join('/');
       params['access_token'] = this.accessToken;
+      params['appsecret_proof'] = this.appsecret_proof;
       url += `?${FacebookAdsApi._encodeParams(params)}`;
     } else {
       url = path;
+      
+    }
+
+    if(this.appsecret_proof ){
+      let connector: string = '?';
+      if(url.indexOf('?') > -1)
+      { 
+        connector ='&';
+      }
+      url += connector + 'appsecret_proof=' + this.appsecret_proof;
     }
     const strUrl: string = (url: any);
+
     return Http.request(method, strUrl, data, files, useMultipartFormData)
       .then(response => {
         if (this._debug) {


### PR DESCRIPTION
Initially the SDK only allowed appsecret_proof to be injected as a param, which causes issues with cursor iteration as explained in #75 . This should resolve the issue.