### PR TITLE
Export abstract crud object for extensions

### DIFF
--- a/src/abstract-crud-object.js
+++ b/src/abstract-crud-object.js
@@ -320,3 +320,6 @@ export class AbstractCrudObject extends AbstractObject {
     });
   }
 }
+
+
+export default AbstractCrudObject

--- a/src/abstract-crud-object.js
+++ b/src/abstract-crud-object.js
@@ -322,4 +322,4 @@ export class AbstractCrudObject extends AbstractObject {
 }
 
 
-export default AbstractCrudObject
+export default AbstractCrudObject;

--- a/src/bundle.es6
+++ b/src/bundle.es6
@@ -8,6 +8,7 @@
 
 export { default as FacebookAdsApi } from './../src/api';
 export { default as FacebookAdsApiBatch } from './../src/api-batch';
+export { default as AbstractCrudObject } from './abstract-crud-object';
 export { default as APIRequest } from './../src/api-request';
 export { default as APIResponse } from './../src/api-response';
 export { default as Ad } from './../src/objects/ad';


### PR DESCRIPTION
There are several search endpoints that are not well defined in the current SDK. Allowing AbstractCrudObject to be exported will allow 3rd parties to extend the SDK while retaining cursor and other functionality and will likely result in more consistant additions and extensions to the SDK as a whole, or as 3rd party modules that are able to easily extend the existing SDK.

