### PR TITLE
OfflineConverseionDataSet#createEvent: pass targetClassConstructor

### DIFF
--- a/src/objects/offline-conversion-data-set.js
+++ b/src/objects/offline-conversion-data-set.js
@@ -124,7 +124,7 @@ export default class OfflineConversionDataSet extends AbstractCrudObject {
       '/events',
       fields,
       params,
-      
+      AbstractObject
     );
   }
 


### PR DESCRIPTION
Addressed https://github.com/facebook/facebook-nodejs-business-sdk/issues/114

In `OfflineConverseionDataSet#createEvent`, passing the `AbstractObject` class as a `targetClassConstructor` to `AbstractCrudObject.createEdge` prevents the behavior described in the issue above. I haven't had time to understand exactly why, but it seems that doing this makes `createEdge` avoid calling `setData`, which tries to mutate the response payload, which appears to be  non-configurable.