### PR TITLE
Standardize country case

### DIFF
--- a/src/objects/serverside/utils.js
+++ b/src/objects/serverside/utils.js
@@ -73,9 +73,7 @@ export default class ServerSideUtils {
    * @return {String} Normalized ISO country code.
    */
   static normalizeCountry (country: string) {
-    country = country.trim().toUpperCase();
-
-    if (country_codes.getCountry(country) == null) {
+    if (country_codes.getCountry(country.toUpperCase()) == null) {
       throw new Error("Invalid country code: '" + country + "'. Please follow ISO 3166-1 2-letter standard for representing country. eg: US");
     }
 


### PR DESCRIPTION
Summary: Our public [documentation](https://developers.facebook.com/docs/marketing-api/server-side-api/parameters/user-data#country) directs users to provide a lowercase country code, but we were sending the code in uppercase in the NodeJS SDK. No other SDK has this issue. Similarly, no other field in the NodeJS SDK is incorrectly normalizing uppercase.

Reviewed By: HeyMultiverse

Differential Revision: D21866159

