### PR TITLE
add check for JSON string

### DIFF
--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -47,6 +47,14 @@ export class FacebookRequestError extends FacebookError {
   }
 }
 
+function isJsonString(str) {
+  try {
+      JSON.parse(str);
+  } catch (e) {
+      return false;
+  }
+  return true;
+}
 /**
  * Error response has several structures depended on called APIs or errors.
  * This method contructs and formats the response into the same structure for
@@ -75,7 +83,7 @@ function constructErrorResponse(response: Object) {
     if (response.name === STATUS_CODE_ERROR) {
       // Handle when we can get response error code
       body = response.error ? response.error : response;
-      body = typeof body === 'string' ? JSON.parse(body) : body;
+      body = typeof body === 'string' && isJsonString(body) ? JSON.parse(body) : body;
       // Construct an error message from subfields in body.error
       message = body.error.error_user_msg
         ? `${body.error.error_user_title}: ${body.error.error_user_msg}`


### PR DESCRIPTION
I'm getting:
{
    "errorType": "Error",
    "errorMessage": "Error: SyntaxError: Unexpected token < in JSON at position 0 with code: 1",
    "stack": [
        "Error: Error: SyntaxError: Unexpected token < in JSON at position 0 with code: 1",
        "    at _homogeneousError (/var/runtime/CallbackContext.js:12:12)",
        "    at postError (/var/runtime/CallbackContext.js:29:54)",
        "    at callback (/var/runtime/CallbackContext.js:41:7)",
        "    at /var/runtime/CallbackContext.js:104:16",
        "    at /var/task/handler.js:15:13",
        "    at processTicksAndRejections (internal/process/task_queues.js:97:5)"
    ]
}

body is not a JSON string and failing