### PR TITLE
bump-sdk-version-to-14

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -21,10 +21,10 @@ export default class FacebookAdsApi {
   locale: string;
   static _defaultApi: FacebookAdsApi;
   static get VERSION(): string {
-    return 'v13.0';
+    return 'v14.0';
   }
   static get SDK_VERSION(): string {
-    return '13.0.0';
+    return '14.0.0';
   }
   static get GRAPH(): string {
     return 'https://graph.facebook.com';


### PR DESCRIPTION
getting the following error when using the latest version of this module
``` You are calling a deprecated version of the Ads API. Please update to the latest version: v14.0. ```

Issue reference: #227 

Updating to v14 seems to work and all tests still pass
