### PR TITLE
Fix issue with cursor params being reset before first succesful api request.

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -48,7 +48,7 @@ export default class Cursor extends Array<Object> {
     }
     this._api = sourceObject.getApi();
     this._targetClass = targetClass;
-    this.paging = {next: next};
+    this.paging = {next: next, params: params};
 
     this.clear = () => {
       this.length = 0;
@@ -84,7 +84,7 @@ export default class Cursor extends Array<Object> {
     this._loadPage = path => {
       const promise = new Promise((resolve, reject) => {
         this._api
-          .call('GET', path, params)
+          .call('GET', path, this.paging.params)
           .then((response: Object) => {
             const objects = this._buildObjectsFromResponse(response);
             this.set(objects);
@@ -95,9 +95,7 @@ export default class Cursor extends Array<Object> {
           })
           .catch(reject);
       });
-      if (params) {
-        params = undefined;
-      }
+
       return promise;
     };
 


### PR DESCRIPTION
Hey,

I've tried to add resiliency to the cursor requests and I've found a bug related to params being reset.

Consider the following scenario:

1. A request is made to the server for data using a cursor object, including specific filters and fields in the params.
2. The server responds with an error (e.g., "Service temporarily unavailable").
3. The user attempts to retry the request by calling cursor.next(). However, instead of the request being retried with the original params (containing the specified filters and fields), the request is sent with default values. This occurs because the params associated with the cursor have been inadvertently reset after the initial request.

The root of the problem was that the cursor's params were not being properly preserved within the cursor's state, leading to the loss of specified filters and fields upon attempting a retry after an error. This made the retry attempt essentially different from the initial request, lacking the intended specificity.

To resolve this issue, I implemented changes to ensure that params are consistently retained within the cursor's state. The key modifications include:

1. Ensuring that the paging object within the cursor is initialized with both next and params properties, the latter holding the initial request parameters.
2. Modifying the _loadPage method to utilize this.paging.params for API calls, guaranteeing that the original parameters are used for retry requests.

By making these changes, we preserve the integrity of the cursor requests, maintaining the specified filters and fields across retry requests. The params value will be overwritten only after first successful request. This fix enhances the robustness of data fetching operations, ensuring that the cursor behaves as expected even in scenarios where server responses may be unreliable.