### PR TITLE
Export FacebookRequestError class by default

### DIFF
--- a/src/bundle.es6
+++ b/src/bundle.es6
@@ -12,6 +12,7 @@ export { default as AbstractCrudObject } from './abstract-crud-object';
 export { default as APIRequest } from './../src/api-request';
 export { default as APIResponse } from './../src/api-response';
 export { default as CrashReporter } from './../src/crash-reporter';
+export { FacebookRequestError } from "./../src/exceptions";
 export { default as Content } from './../src/objects/serverside/content';
 export { default as CustomData } from './../src/objects/serverside/custom-data';
 export { default as EventRequest } from './../src/objects/serverside/event-request';

--- a/src/globals.es6
+++ b/src/globals.es6
@@ -7,6 +7,7 @@
  */
 
 import './../src/api'
+import './../src/exceptions'
 import './../src/objects/ad-video';
 import './../src/objects/alm-ad-account-info';
 import './../src/objects/alm-end-advertiser-info';


### PR DESCRIPTION
This simply adds FacebookRequestError as an exported class in the final build. This enables users to import this class for error handling in applications. Example use cases are found here: https://github.com/facebook/facebook-nodejs-business-sdk/issues/270