### PR TITLE
Handle unexpected end of JSON input for exceptions

### DIFF
--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -63,10 +63,15 @@ function constructErrorResponse(response: Object) {
 
   if (isBatchResponse) {
     // Handle batch response
-    body =
-      typeof response.body === 'string'
-        ? JSON.parse(response.body)
-        : response.body;
+    if (typeof response.body === "string") {
+      try {
+        body = JSON.parse(response.body);
+      } catch (_jsonParseError) {
+        body = response.body;
+      }
+    } else {
+      body = response.body;
+    }
     status = response.code;
     message = body.error.message;
     headers = response.headers;
@@ -76,7 +81,15 @@ function constructErrorResponse(response: Object) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
       body = response.response.data.error ? response.response.data.error : response.response.data;
-      body = typeof body === 'string' ? JSON.parse(body) : body;
+      if (typeof body === "string") {
+        try {
+          body = JSON.parse(body);
+        } catch (_jsonParseError) {
+          body = body;
+        }
+      } else {
+        body = body;
+      }
       message = body.message;
       status = response.response.status;
       headers = response.response.headers;


### PR DESCRIPTION
Some error details cannot be viewed because the error body parse fails on JSON.parse.

Error Stack=>
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at constructErrorResponse (/var/task/node_modules/facebook-nodejs-business-sdk/dist/cjs.js:415:46)
    at new FacebookRequestError (/var/task/node_modules/facebook-nodejs-business-sdk/dist/cjs.js:369:25)
    at /var/task/node_modules/facebook-nodejs-business-sdk/dist/cjs.js:674:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)