### PR TITLE
bump js-sha256 to v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "currency-codes": "^1.5.1",
     "email-validator": "^2.0.4",
     "iso-3166-1": "^2.1.1",
-    "js-sha256": "^0.9.0",
+    "js-sha256": "^0.10.0",
     "mixwith": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`js-sha256@0.9.0` uses `eval` which does not work in cloudflare worker's runtime.

`js-sha256@0.10.0` removed `eval` and use `require` directly. 
https://github.com/emn178/js-sha256/blob/master/CHANGELOG.md#v0100--2023-08-30